### PR TITLE
Radio button fix

### DIFF
--- a/src/components/RadioButton/RadioButton.js
+++ b/src/components/RadioButton/RadioButton.js
@@ -8,7 +8,7 @@ const RadioButton = ({name, options, heading, subtitle, oc, ...props}) => {
 
     var items = options.map((item) =>
         <div className="radio-group">
-            <input name={name} type="radio" id={item.id} value={item.value} onClick={(e) => oc(item.value)}/>
+            <input name={name} type="radio" id={item.id} value={item.value} onClick={oc ? (e) => oc(item.value) : ''}/>
             <label htmlFor={item.id}>{item.label}</label>
         </div>
     );
@@ -32,14 +32,16 @@ RadioButton.propTypes = {
     name: PropTypes.string.isRequired,
     options: PropTypes.array.isRequired,
     heading: PropTypes.string,
-    subtitle: PropTypes.string
+    subtitle: PropTypes.string,
+    oc: PropTypes.func
 }
 
 //Without providing a heading or subtitle, this values default to null
 
 RadioButton.defaultProps = {
     heading: null,
-    subtitle: null
+    subtitle: null,
+    oc: null
 }
 
 //Export

--- a/src/components/TextBox/TextBox.js
+++ b/src/components/TextBox/TextBox.js
@@ -24,17 +24,15 @@ return (
 
 TextBox.propTypes = {
     backgroundColor: PropTypes.string,
-        /** What background colour to use */
     title: PropTypes.string,
-        /** Input contents */
     size: PropTypes.number,
-        /** How large should the input be? */
     maxLength: PropTypes.number,
-    //Maximum input length
     minLength: PropTypes.number,
-    //Minimum input length
     placeholder: PropTypes.string,
     type: PropTypes.oneOf(['text', 'password', 'email', 'tel', 'number', 'date']),
+    min: PropTypes.number,
+    max: PropTypes.number,
+    wrapID: PropTypes.string
 };
 
 TextBox.defaultProps = {


### PR DESCRIPTION
This fix made the 'oc' prop (onClick) for radio buttons optional by using a ternary operator.

Also tidied up and amended prop types and defaults in TextBox.js following on from changes made in the main-form-components branch.