### PR TITLE
Edit CSS for logo (Desktop & Mobile)

### DIFF
--- a/src/components/Header/Headers.css
+++ b/src/components/Header/Headers.css
@@ -1,5 +1,5 @@
 .UCPLogoBlue, .MobileUCPLogoBlue{
-    border-bottom: 1px solid teal;
+    border-bottom: 1px solid white;
     display: block;
 
 }

--- a/src/components/Header/Headers.css
+++ b/src/components/Header/Headers.css
@@ -1,18 +1,18 @@
 .UCPLogoBlue, .MobileUCPLogoBlue{
     border-bottom: 1px solid white;
     display: block;
-
 }
 
 .UCPLogoBlue{
-    margin-top: 5px;
-    margin-left: 5px;
+    margin-top: 10px;
+    margin-left: 10px;
     width: 25%;
 }
 
 .MobileUCPLogoBlue{
-    margin-top: 5px;
+    margin-top: 25px;
     margin-left: auto;
     margin-right: auto;
     width: 95%;
+    display: block;
 }


### PR DESCRIPTION
Changed bottom border line to white so it's not visible on the webpage. Adjusted margins by 100% to allow more space between sides. Moved the logo from the top left for mobile displays to the top-middle. 