### PR TITLE
Fix Terms of Service bypass

### DIFF
--- a/src/components/Buttons/UCPButton.css
+++ b/src/components/Buttons/UCPButton.css
@@ -69,13 +69,13 @@
 
   }
 
-  .mediumbuttom:hover{
+  .mediumbutton:hover{
     background-color: white;
     color: black;
-    width: 400px;
-    height: 200px;
+    width: 125px;
+    height: 75px;
     font-family: 'Montserrat', sans-serif;
-    font-size: 22px;    border-radius: 25px;
+    font-size: 16px;    border-radius: 25px;
     border: 2px solid #005C6E;
     outline: none !important;
 

--- a/src/components/DropdownMenu/DropdownMenu.js
+++ b/src/components/DropdownMenu/DropdownMenu.js
@@ -3,13 +3,15 @@ import './DropdownMenu.css';
 import {isMobile} from 'react-device-detect';
 import {Subjects} from '../../global/Constants';
 
-function DropdownMenu({id, placeholder, options, onSelect, ...props}) {
+function DropdownMenu({id, placeholder, options, onSelect, disabled, ...props}) {
   	let dropdownClassName = isMobile ? "MobileDropdown" : "Dropdown";
 
   	return (
   		<select id={id} 
   			className={dropdownClassName}
-			  onChange={onSelect} >
+			onChange={onSelect}
+			disabled={disabled}
+		>
   			<option value="">{placeholder}</option>
   			{options.map((value, i) => (
   				<option key={i} value={value.value}>{value.label}</option>

--- a/src/components/EssentialApplicantInfo/EssentialApplicantInfo.js
+++ b/src/components/EssentialApplicantInfo/EssentialApplicantInfo.js
@@ -127,6 +127,7 @@ function EssentialApplicantInfo({disabled, ...props}) {
 								primary="True"
 								className="mediumbutton"
 								buttonText="Confirm and Go"
+								disabled={disabled}
 							/>
 						</div>
 					</Col>
@@ -167,6 +168,7 @@ function EssentialApplicantInfo({disabled, ...props}) {
 								primary="True"
 								className="mediumbutton"
 								buttonText="Apply Now"
+								disabled={disabled}
 							/>
 						</div>
 					</Col>
@@ -265,7 +267,7 @@ function EssentialApplicantInfo({disabled, ...props}) {
   						attribute={disabledInputs}
   					/>
   					<h4>Preferred Course</h4>
-  					<DropdownMenu onSelect={(e) => setSelectedCourse(e.target.value)} id="courseSelection"/>
+  					<DropdownMenu disabled={disabled} onSelect={(e) => setSelectedCourse(e.target.value)} id="courseSelection"/>
   				</span>
   			</div>
   			<div>{userTypeSelect()}</div>


### PR DESCRIPTION
Confirm and Go/Apply Now is disabled until you click Accept in the ToS bubble at the top of the StartApplicationPage, as is the course select dropdown, as that could be considered storing data. I also had to tweak a few components to allow this, but best as I can tell I didn't break anything in the process. 

Turns out there was also a bug in the CSS that prevented the buttons from having the select animation (someone spelt it "mediumbutto**m**:hover instead of mediumbutton:hover) so I fixed it because it annoyed me and I doubt that it was the only page affected. Slightly out of scope but oh well, it can easily be reverted if need be for whatever reason and nobody was doing anything CSS this week anyways.

Something additional to consider in the future is making the Request a Callback button not work until a Telephone number is input (or putting a Telephone number input in the Request a Callback menu), as well as doing some styling for the disabled button, but I am not a CSS person. 